### PR TITLE
Added Scopely-MoPub-FacebookAudienceNetwork-Adapters 6.2.0.0.0

### DIFF
--- a/Scopely-MoPub-FacebookAudienceNetwork-Adapters/6.2.0.0.0/Scopely-MoPub-FacebookAudienceNetwork-Adapters.podspec.json
+++ b/Scopely-MoPub-FacebookAudienceNetwork-Adapters/6.2.0.0.0/Scopely-MoPub-FacebookAudienceNetwork-Adapters.podspec.json
@@ -1,0 +1,58 @@
+{
+  "name": "Scopely-MoPub-FacebookAudienceNetwork-Adapters",
+  "version": "6.2.0.0.0",
+  "summary": "Facebook Adapters for mediating through MoPub.",
+  "description": "Supported ad formats: Banners, Interstitial, Rewarded Video and Native.\n\nTo download and integrate the Facebook SDK, please check https://developers.facebook.com/docs/audience-network/ios/#sdk. \n\n\nFor inquiries and support, please visit https://developers.facebook.com/products/audience-network/faq/.",
+  "homepage": "https://github.com/mopub/mopub-ios-mediation",
+  "license": {
+    "type": "New BSD",
+    "file": "LICENSE"
+  },
+  "authors": {
+    "MoPub": "support@mopub.com"
+  },
+  "source": {
+    "git": "https://github.com/mopub/mopub-ios-mediation.git",
+    "tag": "facebookaudiencenetwork-6.2.0.0"
+  },
+  "pod_target_xcconfig": {
+    "EXCLUDED_ARCHS[sdk=iphonesimulator*]": "arm64 arm64e armv7 armv7s",
+    "EXCLUDED_ARCHS[sdk=iphoneos*]": "i386 x86_64"
+  },
+  "user_target_xcconfig": {
+    "EXCLUDED_ARCHS[sdk=iphonesimulator*]": "arm64 arm64e armv7 armv7s",
+    "EXCLUDED_ARCHS[sdk=iphoneos*]": "i386 x86_64"
+  },
+  "platforms": {
+    "ios": "10.0"
+  },
+  "static_framework": true,
+  "subspecs": [
+    {
+      "name": "MoPub",
+      "dependencies": {
+        "mopub-ios-sdk/Core": [
+          "~> 5.13"
+        ],
+        "mopub-ios-sdk/NativeAds": [
+          "~> 5.13"
+        ]
+      }
+    },
+    {
+      "name": "Network",
+      "source_files": "FacebookAudienceNetwork/*.{h,m}",
+      "dependencies": {
+        "mopub-ios-sdk/Core": [
+          "~> 5.13"
+        ],
+        "mopub-ios-sdk/NativeAds": [
+          "~> 5.13"
+        ],
+        "FBAudienceNetwork": [
+          "6.2.1"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Same as the original MoPub adapters for FAN except that they point to FAN 6.2.1 instead of 6.2.0.